### PR TITLE
Ignoring every file ending in '~'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@
 .DS_store
 .env
 yarn.lock
+
+# Emacs temps
+**/*~


### PR DESCRIPTION
Pelo que a gente conversou (+ [esse link](https://askubuntu.com/questions/90515/where-do-files-ending-with-a-come-from)), deve ser o Emacs que gera esses arquivos temporários (que me irritam pra crl).

Não sei se isso conflita com algo do projeto, sempre meto nos meus.