### PR TITLE
Implements shift partition controller

### DIFF
--- a/app/controllers/shift_partitions_controller.rb
+++ b/app/controllers/shift_partitions_controller.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class ShiftPartitionsController < ApplicationController
+  before_action :authenticate_user!, :authenticate_shift_ownership
+
+  rescue_from ActiveRecord::RecordNotFound, with: :redirect_not_found
+  rescue_from ManagementDuty::Errors::TimeOutOfShiftRangeError,
+              with: :redirect_not_found
+  rescue_from ActiveRecord::RecordInvalid, with: :redirect_not_found
+
+  def partitionate
+    ManagementDuty::Shift::Partitionator.new(shift)
+                                        .partitionate_at(partition_time)
+    redirect_to dashboard_path
+  end
+
+  private
+
+  def authenticate_shift_ownership
+    return if shift.user == current_user
+
+    redirect_to dashboard_path
+  end
+
+  def shift
+    @shift ||= Shift.find(params[:id])
+  end
+
+  def redirect_not_found
+    redirect_to dashboard_path
+  end
+
+  def partition_time
+    params[:partition_time]
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,11 +11,11 @@ Rails.application.routes.draw do
   # Welcome Controller
   root 'welcome#index'
   # Dashboard Controller
-  get "/dashboard/:page" => 'dashboard#show'
-  get "/dashboard" => 'dashboard#show'
+  get 'dashboard/:page' => 'dashboard#show'
+  get 'dashboard' => 'dashboard#show'
 
   # Admin controller
-  get "/company/collaborators" => 'admins/invitations#index'
+  get 'company/collaborators' => 'admins/invitations#index'
 
   namespace :users do
     resources :shift_exchanges, only: %i[create index]
@@ -29,4 +29,6 @@ Rails.application.routes.draw do
     put 'shift_exchanges/:id/approve' => 'shift_exchanges#approve'
     put 'shift_exchanges/:id/refuse' => 'shift_exchanges#refuse'
   end
+
+  put 'shift_partitions/:id' => 'shift_partitions#partitionate'
 end

--- a/spec/controllers/shift_partitions_controller_spec.rb
+++ b/spec/controllers/shift_partitions_controller_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'management_duty/errors/time_out_of_shift_range_error'
+
+RSpec.describe ShiftPartitionsController, type: :controller do
+  describe 'PUT #partitionate' do
+    context 'without user session' do
+      it 'redirects to user session path' do
+        put :partitionate, params: { id: 1 }
+
+        expect(subject).to redirect_to(user_session_path)
+      end
+    end
+
+    context 'with user session' do
+      let!(:user) { FactoryBot.create(:user) }
+
+      before { sign_in user }
+      context 'user does not own the shift' do
+        let!(:shift) { FactoryBot.create(:shift, :with_user) }
+
+        it 'redirects to dashboard' do
+          put :partitionate, params: { id: shift.id }
+
+          expect(subject).to redirect_to(dashboard_path)
+        end
+      end
+
+      context 'user owns the shift' do
+        let!(:shift) { FactoryBot.create(:shift, user: user) }
+
+        context 'shift does not exist' do
+          it 'redirects to dashboard' do
+            put :partitionate, params: { id: 99_999 }
+
+            expect(subject).to redirect_to(dashboard_path)
+          end
+        end
+
+        context 'shift exists' do
+          let(:params) do
+            {
+              params: {
+                id: shift.id,
+                partition_time: partition_time
+              }
+            }
+          end
+
+          context 'shift does not contain the param time' do
+            let(:partition_time) { shift.starts_at - 3.hour }
+            it 'redirect_to dashboard' do
+              put :partitionate, params
+
+              expect(subject).to redirect_to(dashboard_path)
+            end
+          end
+
+          context 'new shifts wont be valid' do
+            let(:partition_time) { shift.starts_at + 30.minute }
+            it 'redirect_to dashboard' do
+              put :partitionate, params
+
+              expect(subject).to redirect_to(dashboard_path)
+            end
+          end
+
+          context 'partition is valid' do
+            let(:partition_time) { shift.starts_at + 3.hour }
+            it 'redirects to dashboard' do
+              expect { put :partitionate, params }
+                .to change(::Shift, :count).by(2)
+
+              expect(subject).to redirect_to(dashboard_path)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/routing/shift_paritions_spec.rb
+++ b/spec/routing/shift_paritions_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+RSpec.describe ShiftPartitionsController, type: :routing do
+  describe 'routing' do
+    it 'routes to paritionante' do
+      expect(put: 'shift_partitions/12')
+        .to route_to('shift_partitions#partitionate', id: '12')
+    end
+  end
+end


### PR DESCRIPTION
Implementação da controller de partição de turnos. Ela fica disponível na rota `shift_partitions/:id`, onde `id` é o id do turno. Outro parâmetro, este enviado no body, é o `partitivo_time`, com o formato equivalente ao retornado por `Time.now`. Os redirects são todos para a mesma página porque as páginas para as quais a requisição deveria ser direcionada ainda não existem. Quando os redirects forem corrigidos, os testes devem ser corrigidos junto.